### PR TITLE
Experimental: Added MQTT-based Homie backend support

### DIFF
--- a/sensor/README.md
+++ b/sensor/README.md
@@ -6,21 +6,21 @@ Then go to Tools -> Manage Libraries and install the following libraries:
 * Adafruit SHT31 Library, Version 1.2.0 (not 2.x.x)
 
 # Additional Dependencies - Homie backend
-Add the libraries listed in the Homie "Getting started" guide, e.g. 1a.: [https://homieiot.github.io/homie-esp8266/docs/3.0.0/quickstart/getting-started/]
+Add the libraries listed in the Homie "Getting started" guide, e.g. 1a.: https://homieiot.github.io/homie-esp8266/docs/3.0.0/quickstart/getting-started/
 
 For Homie release 3.0.0:
 
-    Download Homie relase 3.0.0 [https://github.com/homieiot/homie-esp8266/releases/tag/v3.0.0]
-    Load the .zip with Sketch → Include Library → Add .ZIP Library
-
-	Add the Homie dependencies:
-    ArduinoJson >= 5.0.8 [https://github.com/bblanchon/ArduinoJson]
-    Bounce2 [https://github.com/thomasfredericks/Bounce2]
-    ESPAsyncTCP >= c8ed544 [https://github.com/me-no-dev/ESPAsyncTCP]
-    AsyncMqttClient [https://github.com/marvinroger/async-mqtt-client]
-    ESPAsyncWebServer [https://github.com/me-no-dev/ESPAsyncWebServer]
-	
-	Some of them are available through the Arduino IDE, with Sketch → Include Library → Manage Libraries. For the others, install it by downloading the .zip on GitHub.
+> Download Homie relase 3.0.0 https://github.com/homieiot/homie-esp8266/releases/tag/v3.0.0
+> Load the .zip with Sketch → Include Library → Add .ZIP Library
+> 
+> Add the Homie dependencies:
+> ArduinoJson >= 5.0.8 https://github.com/bblanchon/ArduinoJson
+> Bounce2 https://github.com/thomasfredericks/Bounce2
+> ESPAsyncTCP >= c8ed544 https://github.com/me-no-dev/ESPAsyncTCP
+> AsyncMqttClient https://github.com/marvinroger/async-mqtt-client
+> ESPAsyncWebServer https://github.com/me-no-dev/ESPAsyncWebServer
+> 
+> Some of them are available through the Arduino IDE, with Sketch → Include Library → Manage Libraries. For the others, install it by downloading the .zip on GitHub.
 
 # Configuration
 Copy the `config_example.h` to `config.h` and fill out the values.

--- a/sensor/README.md
+++ b/sensor/README.md
@@ -11,14 +11,15 @@ Add the libraries listed in the Homie "Getting started" guide, e.g. 1a.: https:/
 For Homie release 3.0.0:
 
 > Download Homie relase 3.0.0 https://github.com/homieiot/homie-esp8266/releases/tag/v3.0.0
+> 
 > Load the .zip with Sketch → Include Library → Add .ZIP Library
 > 
 > Add the Homie dependencies:
-> ArduinoJson >= 5.0.8 https://github.com/bblanchon/ArduinoJson
-> Bounce2 https://github.com/thomasfredericks/Bounce2
-> ESPAsyncTCP >= c8ed544 https://github.com/me-no-dev/ESPAsyncTCP
-> AsyncMqttClient https://github.com/marvinroger/async-mqtt-client
-> ESPAsyncWebServer https://github.com/me-no-dev/ESPAsyncWebServer
+> * ArduinoJson >= 5.0.8 https://github.com/bblanchon/ArduinoJson
+> * Bounce2 https://github.com/thomasfredericks/Bounce2
+> * ESPAsyncTCP >= c8ed544 https://github.com/me-no-dev/ESPAsyncTCP
+> * AsyncMqttClient https://github.com/marvinroger/async-mqtt-client
+> * ESPAsyncWebServer https://github.com/me-no-dev/ESPAsyncWebServer
 > 
 > Some of them are available through the Arduino IDE, with Sketch → Include Library → Manage Libraries. For the others, install it by downloading the .zip on GitHub.
 

--- a/sensor/README.md
+++ b/sensor/README.md
@@ -5,6 +5,23 @@ Then go to Tools -> Manage Libraries and install the following libraries:
 * Adafruit SGP30 Library, Version 1.2.2
 * Adafruit SHT31 Library, Version 1.2.0 (not 2.x.x)
 
+# Additional Dependencies - Homie backend
+Add the libraries listed in the Homie "Getting started" guide, e.g. 1a.: [https://homieiot.github.io/homie-esp8266/docs/3.0.0/quickstart/getting-started/]
+
+For Homie release 3.0.0:
+
+    Download Homie relase 3.0.0 [https://github.com/homieiot/homie-esp8266/releases/tag/v3.0.0]
+    Load the .zip with Sketch → Include Library → Add .ZIP Library
+
+	Add the Homie dependencies:
+    ArduinoJson >= 5.0.8 [https://github.com/bblanchon/ArduinoJson]
+    Bounce2 [https://github.com/thomasfredericks/Bounce2]
+    ESPAsyncTCP >= c8ed544 [https://github.com/me-no-dev/ESPAsyncTCP]
+    AsyncMqttClient [https://github.com/marvinroger/async-mqtt-client]
+    ESPAsyncWebServer [https://github.com/me-no-dev/ESPAsyncWebServer]
+	
+	Some of them are available through the Arduino IDE, with Sketch → Include Library → Manage Libraries. For the others, install it by downloading the .zip on GitHub.
+
 # Configuration
 Copy the `config_example.h` to `config.h` and fill out the values.
 

--- a/sensor/config_example.h
+++ b/sensor/config_example.h
@@ -1,25 +1,38 @@
-// sensor unit id - sent to backend
-String unitId = "sensor01";
-
-// wifi configuration
-const char* wifi_ssid = "wifiSSID";
-const char* wifi_passwort = "wifiPASSWORD";
-
-// endpoint configuration
-// protocol to use
-String endpointProto = "http://";
-// host of endpoint
-const char* endpointHost = "server.tld";
-// port of endpoint
-const int endpointPort = 80;
-// url of endpoint
-String endpointUrl = "/airquality/api/";
-
-String endpointAddress = endpointProto + endpointHost + ":" + endpointPort + endpointUrl;
+// BACKEND SELECTION
+// Use the homie library to publish sensor data via MQTT
+#undef BACKEND_HOMIE
+// Upload the measurements via HTTP POSE to server
+#define BACKEND_HTTP
 
 // i2c pins - default for D1 Mini
 const int sclPin = D1;
 const int sdaPin = D2;
+
+// SETTINGS FOR HTTP BACKEND
+#ifdef BACKEND_HTTP
+  // sensor unit id - sent to backend
+  String unitId = "sensor01";
+  
+  // wifi configuration
+  const char* wifi_ssid = "wifiSSID";
+  const char* wifi_passwort = "wifiPASSWORD";
+  
+  // endpoint configuration
+  // protocol to use
+  String endpointProto = "http://";
+  // host of endpoint
+  const char* endpointHost = "server.tld";
+  // port of endpoint
+  const int endpointPort = 80;
+  // url of endpoint
+  String endpointUrl = "/airquality/api/";
+  
+  String endpointAddress = endpointProto + endpointHost + ":" + endpointPort + endpointUrl;
+#endif //BACKEND_HTTP
+
+// No settings for BACKEND_HOMIE required, see Hoie docs for config instructions
+//  https://homieiot.github.io/homie-esp8266/docs/2.0.0/configuration/http-json-api/
+//  https://homieiot.github.io/homie-esp8266/docs/3.0.0/configuration/json-configuration-file/
 
 // ADVANCED SETTINGS - THE DEFAULTS ARE PROBABLY OK
 // number of seconds before starting a new measurement (should be 1Hz)


### PR DESCRIPTION
This adds support for the Homie ESP8266 libraries in order to publish the sensor data from one or more sensors to an MQTT broker.
Allows for the use of the sensor in a OpenHab environment.

I've been experiencing some strange wifi issues, so I'm happy for any thoughts on that!